### PR TITLE
Make cooked-goose 'go' installable

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ Now, you can use `cooked-goose` from anywhere on your system.
 
 ---
 
+Alternatively, you can do: 
+
+```
+go install github.com/krlohnes/cooked-goose@latest
+```
+Make sure that you have `$GOBIN` in your `$PATH`. See `https://go.dev/ref/mod#go-install` for more information
+
 ## Usage
 
 ### Command Syntax

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module krlohnes/cooked-goose
+module github.com/krlohnes/cooked-goose
 
 go 1.23.3
 

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"krlohnes/cooked-goose/internal/processor"
+	"github.com/krlohnes/cooked-goose/internal/processor"
 )
 
 func main() {


### PR DESCRIPTION
This is so we can install `cooked-goose` via `go install github.com/krlohnes/cooked-goose@latest`.

If we want to keep the `cmd` directory I can update the PR, but we'll have to call `go install github.com/krlohnes/cooked-goose/cmd@latest`